### PR TITLE
Add dump/autoexec directives to test/code.asm

### DIFF
--- a/test/code.asm
+++ b/test/code.asm
@@ -1,4 +1,8 @@
     org &8000
+
+    dump $            ; not needed by test.bat/trinload.py, but needed if running
+    autoexec          ; `samdisk code.dsk trinity:` (e.g. via vscode-pyz80)
+
     ld  bc,50
     ld  a,7
 loop1:


### PR DESCRIPTION
When trying this out with vscode-pyz80 I realised I needed these directives. Not strictly needed, but maybe helps to avoid confusion. Thanks Simon!